### PR TITLE
Introduce the possibility to set the sender email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Each component runs in an single container and are linked together by docker-com
 
 * :+1: Tested with BareOS 16.2
 * :+1: Tested with BareOS 17.2
-* :+1: Tested with BareOS 18.2 (default version with 'latest' tag) 
+* :+1: Tested with BareOS 18.2 (default version with 'latest' tag)
 
 ## Security advice
 The default passwords inside the configuration files are created when building the docker image. Hence for production either build the image yourself using the sources from Github.
@@ -50,7 +50,7 @@ services:
     #image: barcus/bareos-director:mysql_18 (mysql5.6 with BareOS 18.x)
     #image: barcus/bareos-director:mysql_latest (mysql5.6 with latest BareOS)
     #image: barcus/bareos-director:mysql (same as mysql_latest)
-    image: barcus/bareos-director:latest #(BareOS latest with MySQL) 
+    image: barcus/bareos-director:latest #(BareOS latest with MySQL)
 
     volumes:
       - <BAREOS_CONF_PATH>:/etc/bareos
@@ -65,6 +65,7 @@ services:
       - BAREOS_SD_PASSWORD=ThisIsMySecretSDp4ssw0rd
       - BAREOS_WEBUI_PASSWORD=ThisIsMySecretUIp4ssw0rd
       - SMTP_HOST=smtpd
+      - SENDER_MAIL=your-sender@mail.address #optional
       - ADMIN_MAIL=your@mail.address # Change me!
     depends_on:
       - bareos-db
@@ -125,6 +126,7 @@ services:
 * `<BAREOS_DATA_PATH>` is the path to share your Director data folder from the host side (recommended)
 * DB_PASSWORD must be same as BareOS Database section
 * SMTP_HOST is the name of smtp container
+* SENDER_MAIL is the email address you want to use for send the email # optional, if you don't specify it the ADMIN_MAIL will be used
 * ADMIN_MAIL is your email address
 
 **BareOS Storage Daemon** (bareos-sd)

--- a/build/docker-compose-mysql.yml
+++ b/build/docker-compose-mysql.yml
@@ -12,6 +12,7 @@ bareos-dir:
     - BAREOS_SD_PASSWORD=ThisIsMySecretSDp4ssw0rd
     - BAREOS_WEBUI_PASSWORD=ThisIsMySecretUIp4ssw0rd
     - SMTP_HOST=smtpd
+    - SENDER_MAIL=your-sender@mail.address #optional
     - ADMIN_MAIL=your@mail.address
   links:
     - bareos-fd:bareos-fd

--- a/build/docker-compose-pgsql.yml
+++ b/build/docker-compose-pgsql.yml
@@ -12,6 +12,7 @@ services:
       - BAREOS_SD_PASSWORD=ThisIsMySecretSDp4ssw0rd
       - BAREOS_WEBUI_PASSWORD=ThisIsMySecretUIp4ssw0rd
       - SMTP_HOST=smtpd
+      - SENDER_MAIL=your-sender@mail.address #optional
       - ADMIN_MAIL=your@mail.address
     depends_on:
       - bareos-db

--- a/director-mysql/18.2/docker-entrypoint.sh
+++ b/director-mysql/18.2/docker-entrypoint.sh
@@ -23,8 +23,16 @@ if [ ! -f /etc/bareos/bareos-config.control ]
   sed -i "s#dbuser =.*#dbuser = root#" /etc/bareos/bareos-dir.d/catalog/MyCatalog.conf
   sed -i "s#dbpassword =.*#dbpassword = \"${DB_PASSWORD}\"#" /etc/bareos/bareos-dir.d/catalog/MyCatalog.conf
   sed -i "s#dbname =.*#dbname = bareos\n  dbaddress = \"${DB_HOST}\"\n  dbport = \"${DB_PORT}\"#" /etc/bareos/bareos-dir.d/catalog/MyCatalog.conf
+  if [ ! -z "${SENDER_MAIL}" ]
+      then
+      sed -i 's/\\<%r\\>\\/\\<'${SENDER_MAIL}'\\>\\/g' /etc/bareos/bareos-dir.d/messages/Daemon.conf
+  fi
   sed -i "s#/usr/bin/bsmtp -h root@localhost#/usr/bin/bsmtp -h ${SMTP_HOST}#" /etc/bareos/bareos-dir.d/messages/Daemon.conf
   sed -i "s#mail = root@localhost#mail = ${ADMIN_MAIL}#" /etc/bareos/bareos-dir.d/messages/Daemon.conf
+  if [ ! -z "${SENDER_MAIL}" ]
+      then
+      sed -i 's/\\<%r\\>\\/\\<'${SENDER_MAIL}'\\>\\/g' /etc/bareos/bareos-dir.d/messages/Standard.conf
+  fi
   sed -i "s#/usr/bin/bsmtp -h root@localhost#/usr/bin/bsmtp -h ${SMTP_HOST}#" /etc/bareos/bareos-dir.d/messages/Standard.conf
   sed -i "s#mail = root@localhost#mail = ${ADMIN_MAIL}#" /etc/bareos/bareos-dir.d/messages/Standard.conf
   # storage daemon

--- a/director-pgsql/18.2/docker-entrypoint.sh
+++ b/director-pgsql/18.2/docker-entrypoint.sh
@@ -22,8 +22,16 @@ if [ ! -f /etc/bareos/bareos-config.control ]
   # Director / mycatalog & mail report
   sed -i "s#dbuser = bareos#dbuser = bareos\n  dbpassword = ${DB_PASSWORD}#" /etc/bareos/bareos-dir.d/catalog/MyCatalog.conf
   sed -i "s#dbname = bareos#dbname = bareos\n  dbaddress = \"${DB_HOST}\"\n  dbport = \"${DB_PORT}\"#" /etc/bareos/bareos-dir.d/catalog/MyCatalog.conf
+  if [ ! -z "${SENDER_MAIL}" ]
+      then
+      sed -i 's/\\<%r\\>\\/\\<'${SENDER_MAIL}'\\>\\/g' /etc/bareos/bareos-dir.d/messages/Daemon.conf
+  fi
   sed -i "s#/usr/bin/bsmtp -h root@localhost#/usr/bin/bsmtp -h ${SMTP_HOST}#" /etc/bareos/bareos-dir.d/messages/Daemon.conf
   sed -i "s#mail = root@localhost#mail = ${ADMIN_MAIL}#" /etc/bareos/bareos-dir.d/messages/Daemon.conf
+  if [ ! -z "${SENDER_MAIL}" ]
+      then
+      sed -i 's/\\<%r\\>\\/\\<'${SENDER_MAIL}'\\>\\/g' /etc/bareos/bareos-dir.d/messages/Standard.conf
+  fi
   sed -i "s#/usr/bin/bsmtp -h root@localhost#/usr/bin/bsmtp -h ${SMTP_HOST}#" /etc/bareos/bareos-dir.d/messages/Standard.conf
   sed -i "s#mail = root@localhost#mail = ${ADMIN_MAIL}#" /etc/bareos/bareos-dir.d/messages/Standard.conf
   # storage daemon

--- a/docker-compose-pgsql.yml
+++ b/docker-compose-pgsql.yml
@@ -26,6 +26,7 @@ services:
       - BAREOS_FD_PASSWORD=ThisIsMySecretFDp4ssw0rd
       - BAREOS_WEBUI_PASSWORD=ThisIsMySecretUIp4ssw0rd
       - SMTP_HOST=smtpd
+      - SENDER_MAIL=your-sender@mail.address #optional
       - ADMIN_MAIL=your@mail.address # Change me!
     depends_on:
       - bareos-db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - BAREOS_FD_PASSWORD=ThisIsMySecretFDp4ssw0rd
       - BAREOS_WEBUI_PASSWORD=ThisIsMySecretUIp4ssw0rd
       - SMTP_HOST=smtpd
+      - SENDER_MAIL=your-sender@mail.address #optional
       - ADMIN_MAIL=your@mail.address # Change me!
     depends_on:
       - bareos-db


### PR DESCRIPTION
In some context when there is for example an antispam gateway, you can send the email only with a particular relay email address.
So I've added the variable SENDER_MAIL, it will be set only when the variable is populated.

Note: I've tested the replace with sed manually from bash, I didn't tried the entire process with docker-compose