### PR TITLE
fix for #80: Access denied for tapedrive/autochanger

### DIFF
--- a/storage/16-ubuntu/docker-entrypoint.sh
+++ b/storage/16-ubuntu/docker-entrypoint.sh
@@ -14,7 +14,7 @@ fi
 
 # Fix permissions
 find /etc/bareos/bareos-sd.d ! -user bareos -exec chown bareos {} \;
-chown -R bareos /var/lib/bareos
+chown -R bareos /var/lib/bareos /dev/[n]st* /dev/tape
 
 # Run Dockerfile CMD
 exec "$@"

--- a/storage/17-alpine/docker-entrypoint.sh
+++ b/storage/17-alpine/docker-entrypoint.sh
@@ -14,7 +14,7 @@ fi
 
 # Fix permissions
 find /etc/bareos/bareos-sd.d ! -user bareos -exec chown bareos {} \;
-chown -R bareos /var/lib/bareos
+chown -R bareos /var/lib/bareos /dev/[n]st* /dev/tape
 
 # Run Dockerfile CMD
 exec "$@"

--- a/storage/17-ubuntu/docker-entrypoint.sh
+++ b/storage/17-ubuntu/docker-entrypoint.sh
@@ -14,7 +14,7 @@ fi
 
 # Fix permissions
 find /etc/bareos/bareos-sd.d ! -user bareos -exec chown bareos {} \;
-chown -R bareos /var/lib/bareos
+chown -R bareos /var/lib/bareos /dev/[n]st* /dev/tape
 
 # Run Dockerfile CMD
 exec "$@"

--- a/storage/18-alpine/docker-entrypoint.sh
+++ b/storage/18-alpine/docker-entrypoint.sh
@@ -14,7 +14,7 @@ fi
 
 # Fix permissions
 find /etc/bareos/bareos-sd.d ! -user bareos -exec chown bareos {} \;
-chown -R bareos /var/lib/bareos
+chown -R bareos /var/lib/bareos /dev/[n]st* /dev/tape
 
 # Run Dockerfile CMD
 exec "$@"

--- a/storage/18-ubuntu/docker-entrypoint.sh
+++ b/storage/18-ubuntu/docker-entrypoint.sh
@@ -14,7 +14,7 @@ fi
 
 # Fix permissions
 find /etc/bareos/bareos-sd.d ! -user bareos -exec chown bareos {} \;
-chown -R bareos /var/lib/bareos
+chown -R bareos /var/lib/bareos /dev/[n]st* /dev/tape
 
 # Run Dockerfile CMD
 exec "$@"

--- a/storage/19-alpine/docker-entrypoint.sh
+++ b/storage/19-alpine/docker-entrypoint.sh
@@ -14,7 +14,7 @@ fi
 
 # Fix permissions
 find /etc/bareos/bareos-sd.d ! -user bareos -exec chown bareos {} \;
-chown -R bareos /var/lib/bareos
+chown -R bareos /var/lib/bareos /dev/[n]st* /dev/tape
 
 # Run Dockerfile CMD
 exec "$@"

--- a/storage/19-ubuntu/docker-entrypoint.sh
+++ b/storage/19-ubuntu/docker-entrypoint.sh
@@ -14,7 +14,7 @@ fi
 
 # Fix permissions
 find /etc/bareos/bareos-sd.d ! -user bareos -exec chown bareos {} \;
-chown -R bareos /var/lib/bareos
+chown -R bareos /var/lib/bareos /dev/[n]st* /dev/tape
 
 # Run Dockerfile CMD
 exec "$@"


### PR DESCRIPTION
make autochanger and tape drive device files at common locations available for
bareos-sd.

While this approach might be different from the described one in #80, this probably is the simplest solution to work on mostly any system (independent on the existence of `floppy` or `tape` group).