### PR TITLE
 fix(ci): Updated all download and upload artifacts actions, on v4 artifacts are immutable

### DIFF
--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifact-api
+          name: build-artifact-api-tmp
           path: build
 
   build:
@@ -47,9 +47,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: build-artifact-api
+          name: build-artifact-api-tmp
           path: build
 
       - name: Set up QEMU
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-api
           path: build
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-api
           path: build

--- a/.github/workflows/ci-bareos-app.tmpl
+++ b/.github/workflows/ci-bareos-app.tmpl
@@ -34,7 +34,7 @@ jobs:
           bareos_app: __BAREOS_APP__
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifact-__BAREOS_APP__
           path: build
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Download artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-__BAREOS_APP__
           path: build

--- a/.github/workflows/ci-bareos-app.tmpl
+++ b/.github/workflows/ci-bareos-app.tmpl
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Prepare build file
         uses: ./.github/actions/prepare-bareos-app
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -54,7 +54,7 @@ jobs:
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
         with:
           image: tonistiigi/binfmt:latest
           platforms: all
@@ -63,7 +63,7 @@ jobs:
         uses: ./.github/actions/build-bareos-app
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifact-__BAREOS_APP__
           path: build
@@ -73,17 +73,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-__BAREOS_APP__
           path: build
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
         with:
           image: tonistiigi/binfmt:latest
           platforms: all
@@ -99,10 +99,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-__BAREOS_APP__
           path: build

--- a/.github/workflows/ci-client.yml
+++ b/.github/workflows/ci-client.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-client
           path: build

--- a/.github/workflows/ci-client.yml
+++ b/.github/workflows/ci-client.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifact-client
+          name: build-artifact-client-tmp
           path: build
 
   build:
@@ -49,7 +49,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: build-artifact-client
+          name: build-artifact-client-tmp
           path: build
 
       - name: Set up QEMU
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-client
           path: build
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-client
           path: build

--- a/.github/workflows/ci-director.yml
+++ b/.github/workflows/ci-director.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-director
           path: build

--- a/.github/workflows/ci-director.yml
+++ b/.github/workflows/ci-director.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifact-director
+          name: build-artifact-director-tmp
           path: build
 
   build:
@@ -49,7 +49,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: build-artifact-director
+          name: build-artifact-director-tmp
           path: build
 
       - name: Set up QEMU
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-director
           path: build
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-director
           path: build

--- a/.github/workflows/ci-storage.yml
+++ b/.github/workflows/ci-storage.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-storage
           path: build

--- a/.github/workflows/ci-storage.yml
+++ b/.github/workflows/ci-storage.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifact-storage
+          name: build-artifact-storage-tmp
           path: build
 
   build:
@@ -49,7 +49,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: build-artifact-storage
+          name: build-artifact-storage-tmp
           path: build
 
       - name: Set up QEMU
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-storage
           path: build
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-storage
           path: build

--- a/.github/workflows/ci-webui.yml
+++ b/.github/workflows/ci-webui.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-webui
           path: build

--- a/.github/workflows/ci-webui.yml
+++ b/.github/workflows/ci-webui.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifact-webui
+          name: build-artifact-webui-tmp
           path: build
 
   build:
@@ -49,7 +49,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: build-artifact-webui
+          name: build-artifact-webui-tmp
           path: build
 
       - name: Set up QEMU
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-webui
           path: build
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-webui
           path: build


### PR DESCRIPTION
Hey @barcus, these changes to the ci pipelines are for resolving the current scheduled build issue.
I've bumped the download-artifacs version to v4 and changed artifacts name because on v4 artifacts became immutable, see:
https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md